### PR TITLE
feat(workspaces): add workspaces support and update git-pull-run dependency versioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "git-pull-run",
       "version": "2.0.0",
       "license": "MIT",
+      "workspaces": [
+        "."
+      ],
       "dependencies": {
         "@commander-js/extra-typings": "15.0.0",
         "colorette": "2.0.20",
@@ -31,7 +34,7 @@
         "@types/debug": "4.1.13",
         "@types/node": "24.13.3",
         "@types/picomatch": "4.0.3",
-        "git-pull-run": "latest",
+        "git-pull-run": "*",
         "husky": "9.1.7",
         "jest": "30.4.2",
         "rimraf": "6.1.3",
@@ -4958,24 +4961,8 @@
       }
     },
     "node_modules/git-pull-run": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/git-pull-run/-/git-pull-run-2.0.0.tgz",
-      "integrity": "sha512-vuogq3RsybevIWiBaZ1XKSgTncY/EOY7bw5bNWrbrOTa+RSbhKu1VCZzzjwhPNM2oDixMhE/CuC7t7HfsP3uNA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@commander-js/extra-typings": "15.0.0",
-        "colorette": "2.0.20",
-        "commander": "15.0.0",
-        "debug": "4.4.3",
-        "execa": "10.0.0",
-        "listr2": "10.2.2",
-        "package-manager-detector": "1.7.0",
-        "picomatch": "4.0.5"
-      },
-      "bin": {
-        "git-pull-run": "dist/cli.js"
-      }
+      "resolved": "",
+      "link": true
     },
     "node_modules/glob": {
       "version": "10.5.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
   "files": [
     "dist"
   ],
+  "workspaces": [
+    "."
+  ],
   "scripts": {
     "prebuild": "tsc && npm run format && npm run clean",
     "build": "swc src -d dist --strip-leading-paths",
@@ -70,7 +73,7 @@
     "@types/debug": "4.1.13",
     "@types/node": "24.13.3",
     "@types/picomatch": "4.0.3",
-    "git-pull-run": "latest",
+    "git-pull-run": "*",
     "husky": "9.1.7",
     "jest": "30.4.2",
     "rimraf": "6.1.3",


### PR DESCRIPTION
This prevents new versions that get released from having the lockfile show dependencies from the previously released version.